### PR TITLE
Handle failed QC samples and rerun MultiQC in fastqc pipeline

### DIFF
--- a/ocmstoolkit/.gitignore
+++ b/ocmstoolkit/.gitignore
@@ -1,0 +1,5 @@
+# Swap/backup files
+*.swp
+*.swo
+*.swn
+*.swm


### PR DESCRIPTION
This PR adds functionality to the FastQC pipeline to handle samples that fail QC metrics.
Key Changes
- Automatically moves failed QC samples to a `failed_qc_metric/` folder.
- Reruns `MultiQC` on these failed samples only, to generate a focused report.
- Improves traceability and reporting of problematic samples for downstream analysis