### PR TITLE
GitHub action to tag PR with version number, and increment version number in setup.py

### DIFF
--- a/.github/workflows/tag_on_merge.yml
+++ b/.github/workflows/tag_on_merge.yml
@@ -1,0 +1,112 @@
+name: Tag on PR Merge
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      version_level:
+        description: "Increment version number on PR merge"
+        required: false
+        default: patch
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+jobs:
+  tag:
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # full history
+
+      - name: Fetch all tags
+        run: git fetch --tags --force
+      - name: Debug tags
+        run: |
+          git tag --sort=-creatordate
+          git show-ref --tags
+      - name: Get latest tag
+        id: get_latest_tag
+        run: |
+          latest_tag=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          echo "Latest tag: $latest_tag"
+          echo "latest_tag=$latest_tag" >> "$GITHUB_OUTPUT"
+
+      - name: Determine bump level and bump tag version
+        id: bump_version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_VERSION_LEVEL: ${{ github.event.inputs.version_level }}
+          PR_LABELS: ${{ toJson(github.event.pull_request.labels) }}
+        run: |
+          latest=${{ steps.get_latest_tag.outputs.latest_tag }}
+          echo "Latest tag: $latest"
+
+          # Default bump level
+          level=""
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            level="$INPUT_VERSION_LEVEL"
+          else
+            echo "Detecting bump level from PR labels: $PR_LABELS"
+
+            if echo "$PR_LABELS" | grep -iq '"name":"major"'; then
+              level="major"
+            elif echo "$PR_LABELS" | grep -iq '"name":"minor"'; then
+              level="minor"
+            else
+              level="patch"
+            fi
+          fi
+
+          echo "Determined bump level: $level"
+
+          IFS='.' read -r major minor patch <<<"${latest#v}"
+
+          case "$level" in
+            major)
+              major=$((major + 1)); minor=0; patch=0 ;;
+            minor)
+              minor=$((minor + 1)); patch=0 ;;
+            patch|*)
+              patch=$((patch + 1)) ;;
+          esac
+
+          new_tag="v$major.$minor.$patch"
+          echo "New tag: $new_tag"
+          echo "new_tag=$new_tag" >> "$GITHUB_OUTPUT"
+      - name: Setup SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519_github
+          chmod 600 ~/.ssh/id_ed25519_github
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+      - name: Set SSH remote
+        run: |
+          git remote set-url origin git@github.com:${{ github.repository }}.git
+      - name: Write VERSION file
+        run: echo "${{ steps.bump_version.outputs.new_tag }}" > VERSION
+      - name: Commit and push VERSION file
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add VERSION
+          git commit -m "chore: update VERSION to ${{ steps.bump_version.outputs.new_tag }}" || echo "No changes to commit"
+          git push origin main
+      - name: Push tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag ${{ steps.bump_version.outputs.new_tag }}
+          git push origin ${{ steps.bump_version.outputs.new_tag }}

--- a/.github/workflows/validate_pr_label.yaml
+++ b/.github/workflows/validate_pr_label.yaml
@@ -1,0 +1,38 @@
+name: Validate PR Labels
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+
+jobs:
+  validate-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get PR labels
+        id: pr_labels
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labels = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number
+            });
+            return labels.data.map(label => label.name);
+
+      - name: Validate labels
+        env:
+          PR_LABELS: ${{ steps.pr_labels.outputs.result }}
+        run: |
+          echo "PR Labels: $PR_LABELS"
+          # Count how many of major, minor, patch labels present
+          count=$(echo "$PR_LABELS" | jq '[.[] | select(. == "patch" or . == "minor" or . == "major")] | length')
+
+          echo "Found $count special label(s)"
+
+          if [ "$count" -eq 1 ]; then
+            echo "✅ Exactly one valid label found."
+          else
+            echo "❌ PR must have exactly one of: patch, minor, or major."
+            exit 1
+          fi


### PR DESCRIPTION
This PR adds two GitHub actions that manages the version number in setup.py and applies git tags to each PR, so it is more transparent on the version number people are using.

1) validate that all PRs are labelled as `major`, `minor`, or `patch`
2) extracts latest tag on the repo to get current version number, increments the version number, adds tag to incoming PR, and increments the version number in setup.py

The first action is activated when the PR is created or updated, and it prevents merging without a label assigned to the PR. The second action is activated with the PR is merged into main.

I've tested the two workflows in a sandbox in my own repo, but may need to test this with a dummy PR after this is implemented.