### PR TITLE
GitHub action to tag PR with version number, and increment version number in setup.py

### DIFF
--- a/.github/workflows/tag_on_merge.yml
+++ b/.github/workflows/tag_on_merge.yml
@@ -90,8 +90,8 @@ jobs:
       - name: Setup SSH
         run: |
           mkdir -p ~/.ssh
-          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519_github
-          chmod 600 ~/.ssh/id_ed25519_github
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
           ssh-keyscan github.com >> ~/.ssh/known_hosts
       - name: Set SSH remote
         run: |


### PR DESCRIPTION
This PR adds two GitHub actions that manages the version number in setup.py and applies git tags to each PR, so it is more transparent on the version number people are using.

validate that all PRs are labelled as major, minor, or patch

Patch = bug fixes
Minor = backwards compatible changes (i.e. feature additions etc.)
Major = backwards incompatible changes (i.e. feature removals, base class changes etc.)

The `validate_PR_labels` workflow make sure all PRs contain a major, minor, or patch label
The `tag_on_merge` workflow extracts latest tag on the repo to get current version number, increments the version number, adds tag to incoming PR, and increments the version number in setup.py

The `validate_PR_labels` action is activated when the PR is created or updated, and it prevents merging without a label assigned to the PR. 

The `tag_on_merge` action is activated with the PR is merged into main.

I've tested the two workflows in a sandbox in my own repo, but may need to test this with a dummy PR after this is implemented.

EDIT: Since the last time I tried merging this in, I fixed the SSH key part and added the `sed` statement to update `setup.py`.  This change was tested in my personal sandbox but will need to test it again here with a dummy PR.

