### PR TITLE
parser.add_argument help formatting error

### DIFF
--- a/ocmstoolkit/scripts/rename_and_link.py
+++ b/ocmstoolkit/scripts/rename_and_link.py
@@ -79,7 +79,7 @@ def main(argv=None):
                               " (no file extension)"))
     parser.add_argument("-l", "--log", dest="logfile", type=str,
                         default='read.map',
-                        help="name of log file, default=read.map")
+                        help=("name of log file, default=read.map"))
 
     # unpack commandline arguments
     args = parser.parse_args()


### PR DESCRIPTION
there was a syntax error in `rename_and_link` within `parser.add_argument`. It didn't stop from importing the function but it causes the function to error when trying use it from the command line `ocms_toolkit rename_and_link`